### PR TITLE
Refactor tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea
 
 # C extensions
 *.so

--- a/eventsender/__init__.py
+++ b/eventsender/__init__.py
@@ -1,13 +1,10 @@
 import json
+import os
+from collections import namedtuple
+
 import pika
 import datetime
-from contextlib import closing
-
-try:
-    # Django is not a dependency, but let's allow for simple integration with Django projects
-    from django.conf import settings
-except ImportError:
-    import settings
+from contextlib import closing, contextmanager
 
 
 CONNECTION_ATTEMPTS = 3
@@ -18,23 +15,61 @@ class ImproperlyConfigured(ImportError):
     """ eventsender is somehow improperly configured. """
 
 
+Settings = namedtuple('Settings', ('EVENT_QUEUE_URL', 'EVENT_QUEUE_EXCHANGE', 'EVENT_QUEUE_ROUTING_KEY'))
+
+
+def get_settings():
+    try:
+        # Django is not a dependency, but let's allow for simple integration with Django projects
+        from django.conf import settings
+        return settings
+    except ImportError:
+        return Settings(
+            os.environ.get("EVENT_QUEUE_URL"),
+            os.environ.get("EVENT_QUEUE_EXCHANGE"),
+            os.environ.get("EVENT_QUEUE_ROUTING_KEY")
+        )
+
+
+@contextmanager
+def open_channel(event_queue_url):
+    params = pika.URLParameters(event_queue_url)
+    params.connection_attempts = CONNECTION_ATTEMPTS
+    params.socket_timeout = CONNECTION_TIMEOUT
+    with closing(pika.BlockingConnection(params)) as conn:
+        yield conn.channel()
+
+
+class UTC(datetime.tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+utc = UTC()
+
+
 def send_event(event):
     """
     Add a timestamp to the event data and send it to a message queue
     :param dict event: JSON-serialisable dictionary
     """
+    settings = get_settings()
+
     if not settings.EVENT_QUEUE_URL:
         raise ImproperlyConfigured('EVENT_QUEUE_URL is not configured in settings')
     if not settings.EVENT_QUEUE_EXCHANGE:
         raise ImproperlyConfigured('EVENT_QUEUE_EXCHANGE is not configured in settings')
 
-    event.update({'timestamp': datetime.datetime.now().isoformat()})
-    params = pika.URLParameters(settings.EVENT_QUEUE_URL)
-    params.connection_attempts = CONNECTION_ATTEMPTS
-    params.socket_timeout = CONNECTION_TIMEOUT
-    with closing(pika.BlockingConnection(params)) as conn:
-        chan = conn.channel()
-        chan.basic_publish(
+    event.update({'timestamp': datetime.datetime.now(tz=utc).isoformat()})
+    with open_channel(settings.EVENT_QUEUE_URL) as channel:
+        channel.basic_publish(
             exchange=settings.EVENT_QUEUE_EXCHANGE,
             routing_key=getattr(settings, 'EVENT_QUEUE_ROUTING_KEY', ''),
             body=json.dumps(event),

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,0 @@
-import os
-
-EVENT_QUEUE_URL = os.environ.get('EVENT_QUEUE_URL')
-EVENT_QUEUE_EXCHANGE = os.environ.get('EVENT_QUEUE_EXCHANGE')
-EVENT_QUEUE_ROUTING_KEY = os.environ.get('EVENT_QUEUE_ROUTING_KEY', '')

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+from mock import MagicMock, patch
+from eventsender import Settings
+
+
+class SenderTestCase(TestCase):
+    def set_up_patch(self, topatch, themock=None, **kwargs):
+        """
+        Patch a function or class
+        :param topatch: string The class to patch
+        :param themock: optional object to use as mock
+        :return: mocked object
+        """
+        if themock is None:
+            themock = MagicMock(**kwargs)
+
+        patcher = patch(topatch, themock)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def set_up_settings(self):
+        self.mock_settings = Settings('amqp://host/url', 'exchange', 'key')
+        self.set_up_patch('eventsender.get_settings', return_value=self.mock_settings)

--- a/tests/unit/test_get_settings.py
+++ b/tests/unit/test_get_settings.py
@@ -1,0 +1,14 @@
+from mock import patch
+
+from eventsender import get_settings
+from tests.unit import SenderTestCase
+
+
+class TestGetSettings(SenderTestCase):
+
+    def test_get_settings_fetches_settings_from_environment_if_django_not_installed(self):
+        with patch.dict('os.environ', EVENT_QUEUE_URL='a', EVENT_QUEUE_EXCHANGE='b', EVENT_QUEUE_ROUTING_KEY='c'):
+            settings = get_settings()
+            self.assertEqual(settings.EVENT_QUEUE_URL, 'a')
+            self.assertEqual(settings.EVENT_QUEUE_EXCHANGE, 'b')
+            self.assertEqual(settings.EVENT_QUEUE_ROUTING_KEY, 'c')

--- a/tests/unit/test_open_channel.py
+++ b/tests/unit/test_open_channel.py
@@ -1,0 +1,23 @@
+from eventsender import open_channel
+from tests.unit import SenderTestCase
+
+
+class TestOpenChannel(SenderTestCase):
+    def setUp(self):
+        self.set_up_settings()
+        self.mock_connection = self.set_up_patch('pika.BlockingConnection')
+
+    def test_open_channel_returns_pika_channel(self):
+        mock_channel = self.mock_connection().channel()
+
+        with open_channel("amqp://host/url") as channel:
+            self.assertEqual(channel, mock_channel)
+
+    def test_open_channel_sets_correct_pika_parameters(self):
+        with open_channel("amqp://host/url") as channel:
+            # test if the connection was set up properly
+            _, args, _ = self.mock_connection.mock_calls[0]
+            params = args[0]
+            self.assertEqual(params.connection_attempts, 3)
+            self.assertEqual(params.socket_timeout, 1)
+            self.assertEqual(params.host, "host")

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
 toxworkdir = {env:VIRTUAL_ENV}/.tox
-envlist =
-    py27
+envlist = py27,py34
 
 [testenv]
 deps = -rrequirements.txt
 
 [testenv:py27]
 basepython = python2.7
-commands =
-    nosetests
+commands = nosetests
+
+[testenv:py34]
+basepython = python3.4
+commands = nosetests


### PR DESCRIPTION
I refactored the tests and also changed the way the settings work, so we no longer need the `settings` file dangling around.

1. Use a namedtuple that is resolved in `get_settings`.
2. Move channel opening to `open_channel` so we need fewer mocks per testcase.
3. Send event timestamps in UTC properly.

I could have imported utc from a library, but that would force us to depend on another library and the code is just copied over from [the docs](https://docs.python.org/2/library/datetime.html#datetime.datetime.tzinfo) anyway.