### PR TITLE
Add dynamic exchange for send event

### DIFF
--- a/eventsender/__init__.py
+++ b/eventsender/__init__.py
@@ -55,14 +55,17 @@ class UTC(datetime.tzinfo):
 utc = UTC()
 
 
-def send_event(event, exchange=None):
+def send_event(event, exchange=None, routing_key=None):
     """
     Add a timestamp to the event data and send it to a message queue
     :param dict event: JSON-serialisable dictionary
     :param str exchange: Exchange to use. If not set will default to EVENT_QUEUE_EXCHANGE setting.
+    :param str routing_key: Routing key to use. If not set will default to EVENT_QUEUE_EXCHANGE setting.
+    If this is not set, use blank by default.
     """
     settings = get_settings()
     exchange = exchange or settings.EVENT_QUEUE_EXCHANGE
+    routing_key = routing_key or getattr(settings, 'EVENT_QUEUE_ROUTING_KEY', '')
 
     if not settings.EVENT_QUEUE_URL:
         raise ImproperlyConfigured('EVENT_QUEUE_URL is not configured in settings')
@@ -74,7 +77,7 @@ def send_event(event, exchange=None):
     with open_channel(settings.EVENT_QUEUE_URL) as channel:
         channel.basic_publish(
             exchange=exchange,
-            routing_key=getattr(settings, 'EVENT_QUEUE_ROUTING_KEY', ''),
+            routing_key=routing_key,
             body=json.dumps(event),
             properties=pika.BasicProperties(delivery_mode=2, content_type='application/json')
         )

--- a/eventsender/__init__.py
+++ b/eventsender/__init__.py
@@ -55,22 +55,25 @@ class UTC(datetime.tzinfo):
 utc = UTC()
 
 
-def send_event(event):
+def send_event(event, exchange=None):
     """
     Add a timestamp to the event data and send it to a message queue
     :param dict event: JSON-serialisable dictionary
+    :param str exchange: Exchange to use. If not set will default to EVENT_QUEUE_EXCHANGE setting.
     """
     settings = get_settings()
+    exchange = exchange or settings.EVENT_QUEUE_EXCHANGE
 
     if not settings.EVENT_QUEUE_URL:
         raise ImproperlyConfigured('EVENT_QUEUE_URL is not configured in settings')
-    if not settings.EVENT_QUEUE_EXCHANGE:
-        raise ImproperlyConfigured('EVENT_QUEUE_EXCHANGE is not configured in settings')
+    if not exchange:
+        raise ImproperlyConfigured('EVENT_QUEUE_EXCHANGE is not configured in settings '
+                                   'and no exchange provided in parameters.')
 
     event.update({'timestamp': datetime.datetime.now(tz=utc).isoformat()})
     with open_channel(settings.EVENT_QUEUE_URL) as channel:
         channel.basic_publish(
-            exchange=settings.EVENT_QUEUE_EXCHANGE,
+            exchange=exchange,
             routing_key=getattr(settings, 'EVENT_QUEUE_ROUTING_KEY', ''),
             body=json.dumps(event),
             properties=pika.BasicProperties(delivery_mode=2, content_type='application/json')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readfile(filename):
 
 setup(
     name='eventsender',
-    version='1.1.2',
+    version='1.1.3',
     packages=find_packages(exclude=['tests*']),
     url='https://github.com/ByteInternet/eventsender',
     author='Byte B.V.',


### PR DESCRIPTION
Sometimes it might be nice to define more than one exchange for
`send_event`. In those cases we can provide an override exchange in the
parameters that will take precedence.